### PR TITLE
interruptible CSS transitions

### DIFF
--- a/examples/simple-css.html
+++ b/examples/simple-css.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+  <script src="../dist/flipping.css.js"></script>
+  <style>
+    html, body {
+      height: 100%;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+    }
+
+    .container {
+      width: 600px;
+      height: 300px;
+      margin: auto;
+      margin-top: 3em;
+      display: flex;
+      justify-content: space-between;
+      flex-direction: row;
+    }
+
+    .container--flip {
+      justify-content: flex-start;
+      flex-direction: column;
+    }
+
+    .item {
+      width: 50px;
+      height: 50px;
+      background: red;
+    }
+
+  </style>
+</head>
+<body>
+  <h1>Click this page as fast as you can!</h1>
+  <div class="container">
+    <span class='item' data-flip-key="C">C</span>
+    <span class='item' data-flip-key="S1">S</span>
+    <span class='item' data-flip-key="S2">S</span>
+  </div>
+  <script>
+    const container = document.querySelector( '.container' );
+    const flipping = new Flipping();
+
+    let state = true;
+
+    document.body.addEventListener('click', () => {
+      flipping.read();
+      container.classList.toggle( 'container--flip', state );
+      state = !state
+      flipping.flip();
+    });
+  </script>
+</body>
+</html>

--- a/src/adapters/css.ts
+++ b/src/adapters/css.ts
@@ -30,6 +30,8 @@ const flipStyle = (attr: string) => `
 }
 `;
 
+const matrixRegex = /matrix\(.*, .*, .*, .*, (.*), (.*)\)/;
+
 class FlippingCSS extends Flipping {
   constructor() {
     super({
@@ -38,11 +40,25 @@ class FlippingCSS extends Flipping {
           const state = stateMap[key];
 
           if (state.delta) {
+            
+            let tx = 0;
+            let ty = 0;
+
+            if ( state.bounds && state.bounds.transform )
+            {
+              const match = state.bounds.transform.match(matrixRegex);
+              if ( match && match.length === 3 )
+              {
+                tx = parseFloat( match[1] );
+                ty = parseFloat( match[2] );
+              }
+            }
+
             styleVars(
               state.element as HTMLElement,
               {
-                dx: state.delta.left,
-                dy: state.delta.top,
+                dx: state.delta.left + tx,
+                dy: state.delta.top + ty,
                 dw: state.delta.width,
                 dh: state.delta.height,
                 ...(state.data && state.data.noScale
@@ -54,22 +70,22 @@ class FlippingCSS extends Flipping {
           }
         });
         setTimeout(() => {
-          Object.keys(stateMap).forEach(key => {
-            const state = stateMap[key];
+            Object.keys(stateMap).forEach(key => {
+              const state = stateMap[key];
 
-            if (state.bounds) {
-              styleVars(
-                state.element as HTMLElement,
-                {
-                  dx: 0,
-                  dy: 0,
-                  dw: 1,
-                  dh: 1,
-                  active: 1
-                } as Record<string, any>
-              );
-            }
-          });
+              if (state.bounds) {
+                styleVars(
+                  state.element as HTMLElement,
+                  {
+                    dx: 0,
+                    dy: 0,
+                    dw: 1,
+                    dh: 1,
+                    active: 1
+                  } as Record<string, any>
+                );
+              }
+            });
         }, 0);
       }
     });

--- a/src/adapters/css.ts
+++ b/src/adapters/css.ts
@@ -69,7 +69,8 @@ class FlippingCSS extends Flipping {
             );
           }
         });
-        setTimeout(() => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
             Object.keys(stateMap).forEach(key => {
               const state = stateMap[key];
 
@@ -86,7 +87,8 @@ class FlippingCSS extends Flipping {
                 );
               }
             });
-        }, 0);
+          });
+        });
       }
     });
 


### PR DESCRIPTION
Hey, I noticed that animations using the CSS adapter were not interruptible; the animation would always start from the animating element's un-transformed position. This meant that animations could appear jumpy if you did something to interrupt a flip animation.

To fix this, I updated the css adapter to parse the css transform matrix from getComputedStyle (which i noticed was already being added to the bounds state) and add the transform's translate X & Y values to the dx & dx used when giving the element its inverted style. I also updated the part of the adapter that was triggering the animation because it did not work in firefox. The double request animation frame reliably triggers the animation in the browsers I tested ( chrome, safari, firefox ).

I also added a page to the examples which is what I used to verify the fix.

I dunno if this fits in with how you would approach this problem, but at least this pr might give you some ideas :)

Cheers, and thanks for creating this awesome library!